### PR TITLE
Added logic to prevent Jacknife breaking out of SSL-connections.

### DIFF
--- a/index.php
+++ b/index.php
@@ -25,7 +25,14 @@
 ini_set("zlib.output_compression", "On");
 ini_set("zlib.output_compression", 4096);
 
-define("SELF_URL", "http://" . $_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']."?");
+if( isset( $_SERVER['HTTPS'] ) ) {
+	define("URL_SCHEME", "https" );
+}
+else {
+	define("URL_SCHEME", "http" );
+}
+
+define("SELF_URL", URL_SCHEME."://" . $_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']."?");
 define("AUDIT_PHP", true);
 
 $cookielogin = false;

--- a/manage.php
+++ b/manage.php
@@ -24,7 +24,15 @@
 // ****************************************************************************
 // acount management
 define("MANAGE_PHP", true);
-define("SELF_URL", "http://" . $_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']."?");
+
+if( isset( $_SERVER['HTTPS'] ) ) {
+	define("URL_SCHEME", "https" );
+}
+else {
+	define("URL_SCHEME", "http" );
+}
+
+define("SELF_URL", URL_SCHEME."://" . $_SERVER['HTTP_HOST'].$_SERVER['PHP_SELF']."?");
 
 require_once("eve.php");
 require_once("audit.funcs.php");


### PR DESCRIPTION
I'm using SSL on my site, but since Jackknife uses the prefix http:// to links, it breaks out of SSL. This patch modifies the SELF_URL to reflect if http or https should be used.

I'm not 100% sure if this covers all required links, but I can't find any link that doesn't work with SSL now.
